### PR TITLE
Fix Android isRealDevice for models with Android SDK other than x86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+* [**Fix**] Fix Android isRealDevice for models with Android SDK other than x86
+
 ## 3.2.0
 
 * [**FEAT**] Allow this plugin to run in the background

--- a/android/src/main/kotlin/com/pravera/flutter_security_checker/security/DeviceChecker.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_security_checker/security/DeviceChecker.kt
@@ -13,7 +13,8 @@ class DeviceChecker {
 					|| Build.HARDWARE.contains("ranchu")
 					|| Build.MODEL.contains("google_sdk")
 					|| Build.MODEL.contains("Emulator")
-					|| Build.MODEL.contains("Android SDK built for x86")
+					|| Build.MODEL.contains("Android SDK built for")
+					|| Build.MODEL.startsWith("sdk_")
 					|| Build.MANUFACTURER.contains("Genymotion")
 					|| Build.PRODUCT.contains("sdk_google")
 					|| Build.PRODUCT.contains("google_sdk")
@@ -22,6 +23,14 @@ class DeviceChecker {
 					|| Build.PRODUCT.contains("vbox86p")
 					|| Build.PRODUCT.contains("emulator")
 					|| Build.PRODUCT.contains("simulator")
+					|| Build.DEVICE.startsWith("emulator")
+					// another Android SDK emulator check
+					|| SystemProperties.get("ro.kernel.qemu") == "1"
+					|| Build.PRODUCT.toLowerCase().contains("nox")
+					|| Build.BOARD.toLowerCase().contains("nox")
+					|| Build.HARDWARE.toLowerCase().contains("nox")
+					|| Build.MODEL.toLowerCase().contains("droid4x")
+					|| Build.HARDWARE == "vbox86"
 			return !isEmulator
 		}
 	}

--- a/android/src/main/kotlin/com/pravera/flutter_security_checker/security/DeviceChecker.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_security_checker/security/DeviceChecker.kt
@@ -25,10 +25,10 @@ class DeviceChecker {
 					|| Build.PRODUCT.contains("simulator")
 					|| Build.DEVICE.startsWith("emulator")
 					// another Android SDK emulator check
-					|| Build.PRODUCT.toLowerCase().contains("nox")
-					|| Build.BOARD.toLowerCase().contains("nox")
-					|| Build.HARDWARE.toLowerCase().contains("nox")
-					|| Build.MODEL.toLowerCase().contains("droid4x")
+					|| Build.PRODUCT.lowercase().contains("nox")
+					|| Build.BOARD.lowercase().contains("nox")
+					|| Build.HARDWARE.lowercase().contains("nox")
+					|| Build.MODEL.lowercase().contains("droid4x")
 					|| Build.HARDWARE == "vbox86"
 			return !isEmulator
 		}

--- a/android/src/main/kotlin/com/pravera/flutter_security_checker/security/DeviceChecker.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_security_checker/security/DeviceChecker.kt
@@ -25,7 +25,6 @@ class DeviceChecker {
 					|| Build.PRODUCT.contains("simulator")
 					|| Build.DEVICE.startsWith("emulator")
 					// another Android SDK emulator check
-					|| SystemProperties.get("ro.kernel.qemu") == "1"
 					|| Build.PRODUCT.toLowerCase().contains("nox")
 					|| Build.BOARD.toLowerCase().contains("nox")
 					|| Build.HARDWARE.toLowerCase().contains("nox")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_security_checker
 description: This plugin provides the ability to verify rooting and integrity on Android and iOS platforms.
-version: 3.2.0
+version: 3.2.1
 homepage: https://github.com/Dev-hwang/flutter_security_checker
 
 environment:


### PR DESCRIPTION
Fix Android isRealDevice for models with Android SDK other than x86
some devices could be for arm, not x86 so I removed the architecture text and I add some other emulator devices

![image](https://github.com/user-attachments/assets/8e12a466-2faa-4321-87e2-a1eaaa5a317f)
